### PR TITLE
Implement Instagram Page Feature

### DIFF
--- a/src/api/insta-media/content-types/insta-media/schema.json
+++ b/src/api/insta-media/content-types/insta-media/schema.json
@@ -1,0 +1,23 @@
+{
+  "kind": "singleType",
+  "collectionName": "insta_medias",
+  "info": {
+    "singularName": "insta-media",
+    "pluralName": "insta-medias",
+    "displayName": "Insta_media"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "Cover_img": {
+      "allowedTypes": [
+        "images"
+      ],
+      "type": "media",
+      "multiple": false,
+      "required": true
+    }
+  }
+}

--- a/src/api/insta-media/controllers/insta-media.js
+++ b/src/api/insta-media/controllers/insta-media.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * insta-media controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::insta-media.insta-media');

--- a/src/api/insta-media/routes/insta-media.js
+++ b/src/api/insta-media/routes/insta-media.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * insta-media router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::insta-media.insta-media');

--- a/src/api/insta-media/services/insta-media.js
+++ b/src/api/insta-media/services/insta-media.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * insta-media service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::insta-media.insta-media');

--- a/src/api/insta-post/content-types/insta-post/schema.json
+++ b/src/api/insta-post/content-types/insta-post/schema.json
@@ -15,7 +15,7 @@
     "PostURL": {
       "type": "string",
       "default": "https://www.instagram.com/ubinkakis",
-      "unique": true,
+      "unique": false,
       "required": true
     },
     "CoverImage": {

--- a/src/api/insta-post/content-types/insta-post/schema.json
+++ b/src/api/insta-post/content-types/insta-post/schema.json
@@ -1,0 +1,36 @@
+{
+  "kind": "collectionType",
+  "collectionName": "insta_posts",
+  "info": {
+    "singularName": "insta-post",
+    "pluralName": "insta-posts",
+    "displayName": "InstaPost",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "PostURL": {
+      "type": "string",
+      "default": "https://www.instagram.com/ubinkakis",
+      "unique": true,
+      "required": true
+    },
+    "CoverImage": {
+      "type": "media",
+      "multiple": false,
+      "required": true,
+      "allowedTypes": [
+        "images"
+      ]
+    },
+    "Date": {
+      "type": "datetime",
+      "default": "2022-12-31T16:00:00.000Z",
+      "required": true,
+      "unique": true
+    }
+  }
+}

--- a/src/api/insta-post/controllers/insta-post.js
+++ b/src/api/insta-post/controllers/insta-post.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * insta-post controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::insta-post.insta-post');

--- a/src/api/insta-post/routes/insta-post.js
+++ b/src/api/insta-post/routes/insta-post.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * insta-post router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::insta-post.insta-post');

--- a/src/api/insta-post/services/insta-post.js
+++ b/src/api/insta-post/services/insta-post.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * insta-post service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::insta-post.insta-post');


### PR DESCRIPTION
Add schema for insta posts. Contain post URL, image URL, datetime.
Frontend will then query and make a page that looks like the instagram page. Only show cover photos.